### PR TITLE
Add command-line build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ A macOS menu bar utility that dims everything except the focused app or window, 
 2. Set the run destination to “My Mac (Designed for macOS)”.
 3. Build & run (`⌘R`). macOS will prompt for Accessibility access on first launch.
 
+### Command-line build
+
+If you prefer building without opening Xcode, the package can be compiled with the
+Swift Package Manager:
+
+```bash
+swift build --configuration release
+```
+
+The resulting binary will be emitted to `.build/release/BlurApp`. You can launch it
+directly or from Finder after moving it into `/Applications`.
+
 > **Note:** the CLI harness used by this agent cannot complete `swift build` locally because of sandbox/toolchain constraints; Xcode on a developer machine builds the package without issue.
 
 ## First-Run Checklist


### PR DESCRIPTION
## Summary
- document how to build BlurApp from the command line using Swift Package Manager
- note where the release binary is emitted and how to launch it

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb0759ea4c8332944429ca6b3f05a7