### PR TITLE
Introduce centralized app store for state coordination

### DIFF
--- a/Sources/BlurApp/App/AppAction.swift
+++ b/Sources/BlurApp/App/AppAction.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+import Foundation
+
+/// Defines state mutations the application can perform.
+enum AppAction {
+    case setEnabled(Bool)
+    case setIntensity(Double)
+    case setMode(FocusMode)
+    case setFollowMouse(Bool)
+    case setAnimationDuration(TimeInterval)
+    case setCornerRadius(CGFloat)
+    case setFocusInset(CGFloat)
+    case setFeather(CGFloat)
+    case toggleExclusion(String)
+    case addExclusion(ApplicationIdentity)
+    case recordRecentApplication(ApplicationIdentity)
+    case schedulePause(until: Date)
+    case cancelPause
+}
+
+extension AppAction {
+    /// Indicates whether the action should trigger persistence.
+    var shouldPersistState: Bool {
+        switch self {
+        case .setEnabled,
+             .setIntensity,
+             .setMode,
+             .setFollowMouse,
+             .setAnimationDuration,
+             .setCornerRadius,
+             .setFocusInset,
+             .setFeather,
+             .toggleExclusion,
+             .addExclusion:
+            return true
+        case .recordRecentApplication,
+             .schedulePause,
+             .cancelPause:
+            return false
+        }
+    }
+}

--- a/Sources/BlurApp/App/AppCoordinator.swift
+++ b/Sources/BlurApp/App/AppCoordinator.swift
@@ -1,43 +1,37 @@
 import AppKit
 
 final class AppCoordinator {
-    private let focusEngine: FocusEngine
+    private let store: AppStore
     private let menuBarController: MenuBarController
-    private let preferencesStore: AppPreferencesStore
     private let permissionMonitor: AccessibilityPermissionMonitor
 
     private var preferencesWindow: PreferencesWindowController?
     private var onboardingWindow: AccessibilityOnboardingWindowController?
-    private var pauseTimer: DispatchSourceTimer?
     private var workspaceObserver: NSObjectProtocol?
-
-    private var state: AppState {
-        didSet {
-            menuBarController.refresh(using: state)
-            preferencesWindow?.update(with: state)
-        }
-    }
+    private var stateObserverToken: UUID?
 
     init(
-        focusEngine: FocusEngine = FocusEngine(),
-        preferencesStore: AppPreferencesStore = .shared,
+        store: AppStore = AppStore(),
         permissionMonitor: AccessibilityPermissionMonitor = AccessibilityPermissionMonitor()
     ) {
-        self.focusEngine = focusEngine
-        self.preferencesStore = preferencesStore
+        self.store = store
         self.permissionMonitor = permissionMonitor
-        self.state = preferencesStore.loadState()
         self.menuBarController = MenuBarController()
         self.menuBarController.delegate = self
     }
 
     func start() {
-        menuBarController.refresh(using: state)
+        stateObserverToken = store.subscribe { [weak self] state in
+            guard let self else { return }
+            self.menuBarController.refresh(using: state)
+            self.preferencesWindow?.update(with: state)
+        }
+
         registerWorkspaceObserver()
         registerInitialFrontmostApplication()
 
         if permissionMonitor.isAuthorized {
-            activateFocusEngine()
+            store.activateFocusEngine()
         } else {
             presentOnboardingIfNeeded()
             permissionMonitor.startMonitoring { [weak self] authorized in
@@ -45,15 +39,17 @@ final class AppCoordinator {
                 if authorized {
                     self.permissionMonitor.stopMonitoring()
                     self.dismissOnboarding()
-                    self.activateFocusEngine()
+                    self.store.activateFocusEngine()
                 }
             }
         }
     }
 
     func stop() {
-        pauseTimer?.cancel()
-        pauseTimer = nil
+        if let token = stateObserverToken {
+            store.unsubscribe(token)
+            stateObserverToken = nil
+        }
         if let observer = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
             workspaceObserver = nil
@@ -61,7 +57,7 @@ final class AppCoordinator {
         permissionMonitor.stopMonitoring()
         onboardingWindow?.dismiss()
         preferencesWindow?.close()
-        focusEngine.stop()
+        store.shutdown()
     }
 
     // MARK: - Permissions
@@ -78,31 +74,6 @@ final class AppCoordinator {
     private func dismissOnboarding() {
         onboardingWindow?.dismiss()
         onboardingWindow = nil
-    }
-
-    private func activateFocusEngine() {
-        configureFocusEngine()
-        focusEngine.start()
-        updateFocusEngineEnabledState()
-    }
-
-    private func configureFocusEngine() {
-        focusEngine.setIntensity(state.intensity)
-        focusEngine.setExcludedBundles(state.excludedBundleIdentifiers)
-        focusEngine.updateConfiguration { configuration in
-            configuration.mode = state.mode
-            configuration.followMouse = state.followMouseEnabled
-            configuration.animationDuration = state.animationDuration
-            configuration.cornerRadius = state.cornerRadius
-            configuration.focusInset = state.focusInset
-            configuration.feather = state.feather
-        }
-    }
-
-    private func updateFocusEngineEnabledState() {
-        let now = Date()
-        let isPaused = state.pauseUntil.map { $0 > now } ?? false
-        focusEngine.setEnabled(state.isEnabled && !isPaused)
     }
 
     // MARK: - Workspace Tracking
@@ -130,113 +101,48 @@ final class AppCoordinator {
         guard let bundleID = app.bundleIdentifier else { return }
         let displayName = app.localizedName ?? bundleID
         let identity = ApplicationIdentity(bundleIdentifier: bundleID, displayName: displayName)
-
-        var recent = state.recentApplications
-        recent.removeAll { $0.bundleIdentifier == bundleID }
-        recent.insert(identity, at: 0)
-        if recent.count > 8 {
-            recent = Array(recent.prefix(8))
-        }
-        state.recentApplications = recent
-    }
-
-    // MARK: - Pause Handling
-
-    private func schedulePause(until date: Date) {
-        pauseTimer?.cancel()
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now() + max(0, date.timeIntervalSinceNow))
-        timer.setEventHandler { [weak self] in
-            self?.pauseTimerFired()
-        }
-        timer.resume()
-        pauseTimer = timer
-        state.pauseUntil = date
-        updateFocusEngineEnabledState()
-    }
-
-    private func pauseTimerFired() {
-        pauseTimer?.cancel()
-        pauseTimer = nil
-        state.pauseUntil = nil
-        updateFocusEngineEnabledState()
-    }
-
-    private func cancelPause() {
-        pauseTimer?.cancel()
-        pauseTimer = nil
-        state.pauseUntil = nil
-        updateFocusEngineEnabledState()
-    }
-
-    // MARK: - Persistence
-
-    private func persistState() {
-        preferencesStore.saveState(state)
+        store.dispatch(.recordRecentApplication(identity))
     }
 }
 
 extension AppCoordinator: MenuBarControllerDelegate {
     func menuBarController(_ controller: MenuBarController, didToggleEnabled isEnabled: Bool) {
-        state.isEnabled = isEnabled
-        persistState()
-        updateFocusEngineEnabledState()
-        if isEnabled && permissionMonitor.isAuthorized && !focusEngine.isRunning {
-            activateFocusEngine()
+        store.dispatch(.setEnabled(isEnabled))
+        if isEnabled && permissionMonitor.isAuthorized {
+            store.activateFocusEngine()
         }
     }
 
     func menuBarController(_ controller: MenuBarController, didChangeIntensity value: Double) {
-        state.intensity = value
-        persistState()
-        focusEngine.setIntensity(value)
+        store.dispatch(.setIntensity(value))
     }
 
     func menuBarController(_ controller: MenuBarController, didSelectMode mode: FocusMode) {
-        state.mode = mode
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.mode = mode
-        }
+        store.dispatch(.setMode(mode))
     }
 
     func menuBarController(_ controller: MenuBarController, didToggleFollowMouse isEnabled: Bool) {
-        state.followMouseEnabled = isEnabled
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.followMouse = isEnabled
-        }
+        store.dispatch(.setFollowMouse(isEnabled))
     }
 
     func menuBarController(_ controller: MenuBarController, didRequestPause duration: TimeInterval) {
         let deadline = Date().addingTimeInterval(duration)
-        schedulePause(until: deadline)
+        store.dispatch(.schedulePause(until: deadline))
     }
 
     func menuBarControllerDidRequestResume(_ controller: MenuBarController) {
-        cancelPause()
+        store.dispatch(.cancelPause)
     }
 
     func menuBarController(_ controller: MenuBarController, didToggleExclusion bundleIdentifier: String) {
-        if state.excludedBundleIdentifiers.contains(bundleIdentifier) {
-            state.excludedBundleIdentifiers.remove(bundleIdentifier)
-        } else {
-            state.excludedBundleIdentifiers.insert(bundleIdentifier)
-        }
-        persistState()
-        focusEngine.setExcludedBundles(state.excludedBundleIdentifiers)
+        store.dispatch(.toggleExclusion(bundleIdentifier))
     }
 
     func menuBarControllerDidRequestAddFrontmostAppToExclusions(_ controller: MenuBarController) {
         guard let app = NSWorkspace.shared.frontmostApplication, let bundleID = app.bundleIdentifier else { return }
-        state.excludedBundleIdentifiers.insert(bundleID)
         let displayName = app.localizedName ?? bundleID
         let identity = ApplicationIdentity(bundleIdentifier: bundleID, displayName: displayName)
-        if !state.recentApplications.contains(where: { $0.bundleIdentifier == bundleID }) {
-            state.recentApplications.insert(identity, at: 0)
-        }
-        persistState()
-        focusEngine.setExcludedBundles(state.excludedBundleIdentifiers)
+        store.dispatch(.addExclusion(identity))
     }
 
     func menuBarControllerDidRequestPreferences(_ controller: MenuBarController) {
@@ -245,7 +151,7 @@ extension AppCoordinator: MenuBarControllerDelegate {
             window.preferencesDelegate = self
             preferencesWindow = window
         }
-        preferencesWindow?.update(with: state)
+        preferencesWindow?.update(with: store.currentState)
         preferencesWindow?.present()
     }
 
@@ -263,57 +169,33 @@ extension AppCoordinator: AccessibilityOnboardingDelegate {
         if permissionMonitor.isAuthorized {
             permissionMonitor.stopMonitoring()
             dismissOnboarding()
-            activateFocusEngine()
+            store.activateFocusEngine()
         }
     }
 }
 
 extension AppCoordinator: PreferencesWindowControllerDelegate {
     func preferencesController(_ controller: PreferencesWindowController, didSelectMode mode: FocusMode) {
-        state.mode = mode
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.mode = mode
-        }
+        store.dispatch(.setMode(mode))
     }
 
     func preferencesController(_ controller: PreferencesWindowController, didToggleFollowMouse isEnabled: Bool) {
-        state.followMouseEnabled = isEnabled
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.followMouse = isEnabled
-        }
+        store.dispatch(.setFollowMouse(isEnabled))
     }
 
     func preferencesController(_ controller: PreferencesWindowController, didChangeAnimationDuration value: TimeInterval) {
-        state.animationDuration = value
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.animationDuration = value
-        }
+        store.dispatch(.setAnimationDuration(value))
     }
 
     func preferencesController(_ controller: PreferencesWindowController, didChangeCornerRadius value: CGFloat) {
-        state.cornerRadius = value
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.cornerRadius = value
-        }
+        store.dispatch(.setCornerRadius(value))
     }
 
     func preferencesController(_ controller: PreferencesWindowController, didChangeFocusInset value: CGFloat) {
-        state.focusInset = value
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.focusInset = value
-        }
+        store.dispatch(.setFocusInset(value))
     }
 
     func preferencesController(_ controller: PreferencesWindowController, didChangeFeather value: CGFloat) {
-        state.feather = value
-        persistState()
-        focusEngine.updateConfiguration { configuration in
-            configuration.feather = value
-        }
+        store.dispatch(.setFeather(value))
     }
 }

--- a/Sources/BlurApp/App/AppEnvironment.swift
+++ b/Sources/BlurApp/App/AppEnvironment.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct AppEnvironment {
+    var focusEngine: FocusEngine
+    var preferencesStore: AppPreferencesStore
+    var dateProvider: () -> Date
+
+    static func live(
+        focusEngine: FocusEngine = FocusEngine(),
+        preferencesStore: AppPreferencesStore = .shared,
+        dateProvider: @escaping () -> Date = Date.init
+    ) -> AppEnvironment {
+        AppEnvironment(
+            focusEngine: focusEngine,
+            preferencesStore: preferencesStore,
+            dateProvider: dateProvider
+        )
+    }
+}

--- a/Sources/BlurApp/App/AppStore.swift
+++ b/Sources/BlurApp/App/AppStore.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+final class AppStore {
+    private enum Constants {
+        static let maxRecentApplications = 8
+    }
+
+    private let environment: AppEnvironment
+    private var observers: [UUID: (AppState) -> Void] = [:]
+    private var pauseTimer: DispatchSourceTimer?
+    private var isFocusEngineActive = false
+
+    private(set) var state: AppState
+
+    var currentState: AppState { state }
+
+    init(environment: AppEnvironment = .live()) {
+        self.environment = environment
+        var initialState = environment.preferencesStore.loadState()
+        if let pauseUntil = initialState.pauseUntil, pauseUntil <= environment.dateProvider() {
+            initialState.pauseUntil = nil
+        }
+        state = initialState
+    }
+
+    deinit {
+        shutdown()
+    }
+
+    @discardableResult
+    func subscribe(_ observer: @escaping (AppState) -> Void) -> UUID {
+        let token = UUID()
+        observers[token] = observer
+        observer(state)
+        return token
+    }
+
+    func unsubscribe(_ token: UUID) {
+        observers.removeValue(forKey: token)
+    }
+
+    func dispatch(_ action: AppAction) {
+        var newState = state
+        let didMutate = reduce(&newState, action: action)
+        if didMutate {
+            let previousState = state
+            state = newState
+            if action.shouldPersistState {
+                environment.preferencesStore.saveState(state)
+            }
+            synchronizeFocusEngine(from: previousState)
+            notifyObservers()
+        }
+        handleSideEffects(for: action)
+    }
+
+    func activateFocusEngine() {
+        guard !isFocusEngineActive else { return }
+        configureFocusEngine()
+        environment.focusEngine.start()
+        isFocusEngineActive = true
+        environment.focusEngine.setEnabled(isFocusEngineEnabled(for: state))
+    }
+
+    func shutdown() {
+        pauseTimer?.cancel()
+        pauseTimer = nil
+        if isFocusEngineActive {
+            environment.focusEngine.stop()
+            isFocusEngineActive = false
+        }
+    }
+
+    // MARK: - Reducer
+
+    private func reduce(_ state: inout AppState, action: AppAction) -> Bool {
+        switch action {
+        case let .setEnabled(isEnabled):
+            guard state.isEnabled != isEnabled else { return false }
+            state.isEnabled = isEnabled
+            return true
+
+        case let .setIntensity(value):
+            let clamped = max(0.0, min(value, 1.0))
+            guard state.intensity != clamped else { return false }
+            state.intensity = clamped
+            return true
+
+        case let .setMode(mode):
+            guard state.mode != mode else { return false }
+            state.mode = mode
+            return true
+
+        case let .setFollowMouse(isEnabled):
+            guard state.followMouseEnabled != isEnabled else { return false }
+            state.followMouseEnabled = isEnabled
+            return true
+
+        case let .setAnimationDuration(duration):
+            guard state.animationDuration != duration else { return false }
+            state.animationDuration = duration
+            return true
+
+        case let .setCornerRadius(radius):
+            guard state.cornerRadius != radius else { return false }
+            state.cornerRadius = radius
+            return true
+
+        case let .setFocusInset(inset):
+            guard state.focusInset != inset else { return false }
+            state.focusInset = inset
+            return true
+
+        case let .setFeather(feather):
+            guard state.feather != feather else { return false }
+            state.feather = feather
+            return true
+
+        case let .toggleExclusion(bundleIdentifier):
+            if state.excludedBundleIdentifiers.contains(bundleIdentifier) {
+                state.excludedBundleIdentifiers.remove(bundleIdentifier)
+            } else {
+                state.excludedBundleIdentifiers.insert(bundleIdentifier)
+            }
+            return true
+
+        case let .addExclusion(identity):
+            let inserted = state.excludedBundleIdentifiers.insert(identity.bundleIdentifier).inserted
+            let recentsChanged = insertRecentApplication(identity, into: &state)
+            return inserted || recentsChanged
+
+        case let .recordRecentApplication(identity):
+            return insertRecentApplication(identity, into: &state)
+
+        case let .schedulePause(until: deadline):
+            guard state.pauseUntil != deadline else { return false }
+            state.pauseUntil = deadline
+            return true
+
+        case .cancelPause:
+            guard state.pauseUntil != nil else { return false }
+            state.pauseUntil = nil
+            return true
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func insertRecentApplication(_ identity: ApplicationIdentity, into state: inout AppState) -> Bool {
+        var recent = state.recentApplications
+        recent.removeAll { $0.bundleIdentifier == identity.bundleIdentifier }
+        recent.insert(identity, at: 0)
+        if recent.count > Constants.maxRecentApplications {
+            recent = Array(recent.prefix(Constants.maxRecentApplications))
+        }
+        guard recent != state.recentApplications else { return false }
+        state.recentApplications = recent
+        return true
+    }
+
+    private func configureFocusEngine() {
+        environment.focusEngine.setIntensity(state.intensity)
+        environment.focusEngine.setExcludedBundles(state.excludedBundleIdentifiers)
+        environment.focusEngine.updateConfiguration { configuration in
+            configuration.mode = state.mode
+            configuration.followMouse = state.followMouseEnabled
+            configuration.animationDuration = state.animationDuration
+            configuration.cornerRadius = state.cornerRadius
+            configuration.focusInset = state.focusInset
+            configuration.feather = state.feather
+        }
+    }
+
+    private func synchronizeFocusEngine(from previousState: AppState) {
+        guard isFocusEngineActive else { return }
+
+        if previousState.intensity != state.intensity {
+            environment.focusEngine.setIntensity(state.intensity)
+        }
+
+        if previousState.excludedBundleIdentifiers != state.excludedBundleIdentifiers {
+            environment.focusEngine.setExcludedBundles(state.excludedBundleIdentifiers)
+        }
+
+        let configurationChanged =
+            previousState.mode != state.mode ||
+            previousState.followMouseEnabled != state.followMouseEnabled ||
+            previousState.animationDuration != state.animationDuration ||
+            previousState.cornerRadius != state.cornerRadius ||
+            previousState.focusInset != state.focusInset ||
+            previousState.feather != state.feather
+
+        if configurationChanged {
+            environment.focusEngine.updateConfiguration { configuration in
+                configuration.mode = state.mode
+                configuration.followMouse = state.followMouseEnabled
+                configuration.animationDuration = state.animationDuration
+                configuration.cornerRadius = state.cornerRadius
+                configuration.focusInset = state.focusInset
+                configuration.feather = state.feather
+            }
+        }
+
+        let previouslyEnabled = isFocusEngineEnabled(for: previousState)
+        let currentlyEnabled = isFocusEngineEnabled(for: state)
+        if previouslyEnabled != currentlyEnabled {
+            environment.focusEngine.setEnabled(currentlyEnabled)
+        }
+    }
+
+    private func isFocusEngineEnabled(for state: AppState) -> Bool {
+        let now = environment.dateProvider()
+        let isPaused = state.pauseUntil.map { $0 > now } ?? false
+        return state.isEnabled && !isPaused
+    }
+
+    private func handleSideEffects(for action: AppAction) {
+        switch action {
+        case let .schedulePause(until: deadline):
+            schedulePauseTimer(until: deadline)
+        case .cancelPause:
+            cancelPauseTimer()
+        default:
+            break
+        }
+    }
+
+    private func schedulePauseTimer(until deadline: Date) {
+        pauseTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        let now = environment.dateProvider()
+        let interval = max(0, deadline.timeIntervalSince(now))
+        timer.schedule(deadline: .now() + interval)
+        timer.setEventHandler { [weak self] in
+            self?.handlePauseTimerFired()
+        }
+        timer.resume()
+        pauseTimer = timer
+    }
+
+    private func cancelPauseTimer() {
+        pauseTimer?.cancel()
+        pauseTimer = nil
+    }
+
+    private func handlePauseTimerFired() {
+        cancelPauseTimer()
+        var newState = state
+        let didMutate = reduce(&newState, action: .cancelPause)
+        guard didMutate else { return }
+        let previousState = state
+        state = newState
+        synchronizeFocusEngine(from: previousState)
+        notifyObservers()
+    }
+
+    private func notifyObservers() {
+        observers.values.forEach { observer in
+            observer(state)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an `AppStore` abstraction with `AppAction` and `AppEnvironment` to centralize state changes and dependency wiring
- migrate `AppCoordinator` to dispatch actions to the store and subscribe to state updates for UI refreshes
- move pause handling, persistence, and focus engine synchronization into the store for a cleaner architecture

## Testing
- swift build *(fails: package requires Swift tools 6.2.0 but 6.1.0 is installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0cf1ac1c8332bda47efdb24cad66