### PR TITLE
Start AppKit run loop from main entry point

### DIFF
--- a/Sources/BlurApp/blurapp.swift
+++ b/Sources/BlurApp/blurapp.swift
@@ -1,9 +1,14 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+import AppKit
 
 @main
-struct blurapp {
+enum BlurAppMain {
     static func main() {
-        print("Hello, world!")
+        if Thread.isMainThread {
+            startBlurApp()
+        } else {
+            DispatchQueue.main.sync {
+                startBlurApp()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the placeholder Hello World entry point with the real BlurApp startup
- ensure the AppKit application delegate is launched on the main thread

## Testing
- `swift test` *(fails: package requires Swift tools 6.2.0 but 6.1.0 is installed in the CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2178ffd88332b73d7e81e9cf2fa6