### PR TITLE
Fix window snapshot lookup when using AXWindowNumber

### DIFF
--- a/Sources/BlurApp/Focus/AccessibilityWindowTracker.swift
+++ b/Sources/BlurApp/Focus/AccessibilityWindowTracker.swift
@@ -148,10 +148,10 @@ final class AccessibilityWindowTracker {
         guard isStandardWindow(element: element) else { return nil }
         guard let frame = fetchFrame(for: element) else { return nil }
         guard let screenID = screenIdentifier(for: frame) else { return nil }
-        guard let windowNumber: Int = copyAttributeValue(element: element, attribute: kAXWindowNumberAttribute) else { return nil }
+        guard let windowNumberValue: NSNumber = copyAttributeValue(element: element, attribute: kAXWindowNumberAttribute) else { return nil }
 
         return WindowSnapshot(
-            windowID: CGWindowID(windowNumber),
+            windowID: CGWindowID(windowNumberValue.uint32Value),
             frame: frame,
             screenID: screenID,
             appBundleIdentifier: bundleIdentifier


### PR DESCRIPTION
## Summary
- treat the Accessibility window number attribute as an NSNumber before converting to a CGWindowID
- ensure window snapshots are still produced when accessibility returns CFNumber values

## Testing
- swift test *(fails: required Swift tools version 6.2.0 is newer than the installed 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cb242874bc8332a56a4604ffaabd44