### PR TITLE
Remove outer padding from intensity control

### DIFF
--- a/Sources/BlurApp/UI/IntensityControlView.swift
+++ b/Sources/BlurApp/UI/IntensityControlView.swift
@@ -27,10 +27,10 @@ final class IntensityControlView: NSView {
         glassView.addSubview(slider)
 
         NSLayoutConstraint.activate([
-            glassView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
-            glassView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
-            glassView.topAnchor.constraint(equalTo: topAnchor, constant: 4),
-            glassView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            glassView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            glassView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            glassView.topAnchor.constraint(equalTo: topAnchor),
+            glassView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             titleLabel.leadingAnchor.constraint(equalTo: glassView.leadingAnchor, constant: 16),
             titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: glassView.trailingAnchor, constant: -16),


### PR DESCRIPTION
## Summary
- remove the extra edge insets around the glass container so it fills the window

## Testing
- swift test *(fails: package requires Swift tools 6.2.0 but 6.1.0 is installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb8cb92088332bf41c047f437e0ff