### PR TITLE
Include auxiliary windows in focus highlights

### DIFF
--- a/Sources/BlurApp/Focus/AccessibilityWindowTracker.swift
+++ b/Sources/BlurApp/Focus/AccessibilityWindowTracker.swift
@@ -196,12 +196,16 @@ final class AccessibilityWindowTracker {
         guard let subrole: String = copyAttributeValue(element: element, attribute: kAXSubroleAttribute) else {
             return true
         }
+
+        // We intentionally include floating panels, sheets and other auxiliary
+        // windows that belong to the focused application so that the dimming
+        // overlay never covers controls or popovers that appear above the
+        // primary window. Only exclude a small set of known non-visual
+        // containers.
         let excludedSubroles: Set<String> = [
-            kAXSystemDialogSubrole as String,
-            kAXFloatingWindowSubrole as String,
-            kAXSheetSubrole as String,
-            "AXPopover"
+            "AXUnknown"
         ]
+
         return !excludedSubroles.contains(subrole)
     }
 


### PR DESCRIPTION
## Summary
- allow auxiliary frontmost windows such as sheets, popovers, and floating panels to be treated as focus targets by the accessibility tracker
- document the intent inside `AccessibilityWindowTracker` so the overlay leaves room for controls that appear above the primary window

## Testing
- `swift test` *(fails: package requires Swift tools 6.2.0 while environment provides 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbabebbec8332aa8e6bcc63d2cc55