### PR TITLE
Improve focus overlay coverage and responsiveness

### DIFF
--- a/Sources/BlurApp/App/AppState.swift
+++ b/Sources/BlurApp/App/AppState.swift
@@ -11,7 +11,7 @@ struct AppState {
     var recentApplications: [ApplicationIdentity] = []
     var animationDuration: TimeInterval = 0.2
     var cornerRadius: CGFloat = 8
-    var focusInset: CGFloat = 6
+    var focusInset: CGFloat = 0
     var feather: CGFloat = 12
 }
 

--- a/Sources/BlurApp/Focus/DimOverlayView.swift
+++ b/Sources/BlurApp/Focus/DimOverlayView.swift
@@ -17,6 +17,7 @@ final class DimOverlayView: NSView {
         dimLayer.opacity = 0
         dimLayer.fillRule = .evenOdd
         dimLayer.frame = bounds
+        dimLayer.allowsEdgeAntialiasing = false
         layer?.addSublayer(dimLayer)
     }
 
@@ -28,6 +29,8 @@ final class DimOverlayView: NSView {
     override func layout() {
         super.layout()
         dimLayer.frame = bounds
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        dimLayer.contentsScale = scale
     }
 
     func update(
@@ -38,7 +41,8 @@ final class DimOverlayView: NSView {
         animated: Bool
     ) {
         let path = CGMutablePath()
-        path.addRect(bounds)
+        let expandedBounds = bounds.insetBy(dx: -2, dy: -2)
+        path.addRect(expandedBounds)
 
         for rect in holes {
             let roundedRect = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)

--- a/Sources/BlurApp/Focus/FocusConfiguration.swift
+++ b/Sources/BlurApp/Focus/FocusConfiguration.swift
@@ -6,6 +6,6 @@ struct FocusConfiguration {
     var followMouse: Bool = false
     var animationDuration: TimeInterval = 0.2
     var cornerRadius: CGFloat = 8
-    var focusInset: CGFloat = 6
+    var focusInset: CGFloat = 0
     var feather: CGFloat = 12
 }

--- a/Sources/BlurApp/Focus/FocusEngine.swift
+++ b/Sources/BlurApp/Focus/FocusEngine.swift
@@ -8,8 +8,8 @@ import OSLog
 @MainActor
 final class FocusEngine {
     private struct Constants {
-        static let refreshThrottle: TimeInterval = 0.08
-        static let mouseThrottle: TimeInterval = 0.18
+        static let refreshThrottle: TimeInterval = 0.02
+        static let mouseThrottle: TimeInterval = 0.05
     }
 
     private let log = Logger(subsystem: "com.blurapp.core", category: "FocusEngine")
@@ -342,7 +342,8 @@ final class FocusEngine {
         let screenBounds = CGRect(origin: .zero, size: overlayFrame.size)
         rect = rect.intersection(screenBounds)
         guard !rect.isNull, !rect.isEmpty else { return nil }
-        return rect
+        let scale = screen.backingScaleFactor
+        return pixelAlignedRect(rect, scale: scale)
     }
 
     private func shouldHideForFullScreen(screenSnapshots: [WindowSnapshot], screen: NSScreen) -> Bool {
@@ -440,6 +441,20 @@ final class FocusEngine {
 
     private func clamp(_ value: Double, lower: Double, upper: Double) -> Double {
         min(max(value, lower), upper)
+    }
+
+    private func pixelAlignedRect(_ rect: CGRect, scale: CGFloat) -> CGRect {
+        guard scale > 0 else { return rect.integral }
+        var aligned = rect
+        let originX = (rect.origin.x * scale).rounded(.down) / scale
+        let originY = (rect.origin.y * scale).rounded(.down) / scale
+        let maxX = (rect.maxX * scale).rounded(.up) / scale
+        let maxY = (rect.maxY * scale).rounded(.up) / scale
+        aligned.origin.x = originX
+        aligned.origin.y = originY
+        aligned.size.width = maxX - originX
+        aligned.size.height = maxY - originY
+        return aligned
     }
 }
 

--- a/Sources/BlurApp/Preferences/AppPreferencesStore.swift
+++ b/Sources/BlurApp/Preferences/AppPreferencesStore.swift
@@ -40,7 +40,7 @@ final class AppPreferencesStore {
             state.excludedBundleIdentifiers = Set(payload.excludedBundleIdentifiers)
             state.animationDuration = payload.animationDuration
             state.cornerRadius = CGFloat(payload.cornerRadius)
-            state.focusInset = CGFloat(payload.focusInset)
+            state.focusInset = max(0, CGFloat(payload.focusInset))
             state.feather = CGFloat(payload.feather)
             return state
         } catch {
@@ -58,7 +58,7 @@ final class AppPreferencesStore {
             excludedBundleIdentifiers: Array(state.excludedBundleIdentifiers),
             animationDuration: state.animationDuration,
             cornerRadius: Double(state.cornerRadius),
-            focusInset: Double(state.focusInset),
+            focusInset: Double(max(0, state.focusInset)),
             feather: Double(state.feather)
         )
 

--- a/Tests/BlurAppTests/AppPreferencesStoreTests.swift
+++ b/Tests/BlurAppTests/AppPreferencesStoreTests.swift
@@ -96,6 +96,27 @@ final class AppPreferencesStoreTests: XCTestCase {
         XCTAssertEqual(state.feather, CGFloat(payload.feather))
     }
 
+    func testLoadStateClampsNegativeFocusInsetToZero() throws {
+        let payload = StoredPreferencesPayload(
+            isEnabled: true,
+            intensity: 0.5,
+            mode: .activeApp,
+            followMouseEnabled: false,
+            excludedBundleIdentifiers: [],
+            animationDuration: 0.2,
+            cornerRadius: 10,
+            focusInset: -5,
+            feather: 12
+        )
+
+        let data = try JSONEncoder().encode(payload)
+        defaults.set(data, forKey: "com.blurapp.preferences.v1")
+
+        let state = store.loadState()
+
+        XCTAssertEqual(state.focusInset, 0)
+    }
+
     func testLoadStateWithCorruptedDataResetsStore() {
         defaults.set(Data([0x00, 0x01]), forKey: "com.blurapp.preferences.v1")
 


### PR DESCRIPTION
## Summary
- eliminate the default gap between the focused window and dimming overlay and expand the overlay bounds to cover the entire display
- align focused window cutouts to pixel boundaries and reduce refresh throttling for smoother updates
- clamp stored focus inset values to non-negative numbers and add a regression test for the preference store

## Testing
- `swift test` *(fails: package requires Swift tools 6.2.0 but 6.1.0 is installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc4e8cc408332b7797fd51d7962fe